### PR TITLE
Move temp-directory creation/deletion into common

### DIFF
--- a/test/test-crc-output
+++ b/test/test-crc-output
@@ -38,7 +38,6 @@ test_archive() {
 
 	# CRC test:
 
-	wd=$(mktemp -td test-crc-output.XXXXXX)
 	test_lha t archives/$archive > "$wd/t.txt"
 
 	if ! diff -u output/$archive-t.txt "$wd/t.txt"; then

--- a/test/test-decompress
+++ b/test/test-decompress
@@ -27,7 +27,6 @@
 test_archive() {
 	local archive=$1
 
-	wd=$(mktemp -td test-decompress.XXXXXX)
 	(echo "crc: $2"; echo "length: $3") > "$wd/expected.txt"
 
 	./decompress-crc "archives/$archive" > "$wd/output.txt"

--- a/test/test-dry-run
+++ b/test/test-dry-run
@@ -32,7 +32,6 @@ test_dry_run() {
 		archive_file="archives/$archive_file"
 	fi
 
-	wd=$(mktemp -td test-dry-run.XXXXXX)
 	# Only check the last line of output:
 
 	echo "$expected" > "$wd/expected.txt"
@@ -45,7 +44,6 @@ test_dry_run() {
 	fi
 
 	rm -f "$wd/expected.txt" "$wd/output.txt" "$wd/output2.txt"
-	rmdir "$wd" || find "$wd"
 }
 
 test_archive() {

--- a/test/test-extract
+++ b/test/test-extract
@@ -22,8 +22,6 @@
 
 . test_common.sh
 
-wd="$(mktemp -td lhasa-test-extract.XXXXX)"
-trap "rmdir '$wd'" INT EXIT
 run_sandbox="$wd/extract1"
 w_sandbox="$wd/extract2"
 gather_sandbox="$wd/extract3"

--- a/test/test-file-headers
+++ b/test/test-file-headers
@@ -28,7 +28,6 @@ test_archive() {
 	local archive=$1
 	local expected="output/$archive-hdr.txt"
 
-	wd=$(mktemp -td test-file-headers.XXXXXX)
 	./dump-headers "archives/$archive" > "$wd/hdr.txt"
 
 	if [ ! -e "$expected" ]; then

--- a/test/test-list-output
+++ b/test/test-list-output
@@ -30,7 +30,6 @@ check_output() {
 	# Check the output for a particular option matches the expected
 	# output file.
 
-	wd=$(mktemp -td test-list-output.XXXXXX)
 	test_lha "$@" > "$wd/tmp.txt"
 
 	if ! diff -u output/$expected "$wd/tmp.txt"; then

--- a/test/test-print
+++ b/test/test-print
@@ -30,7 +30,6 @@ lha_check_output() {
 	local expected_output="$1"
 	shift
 
-        wd=$(mktemp -td test-print.XXXXXX)
 	test_lha "$@" >"$wd/output.txt" 2>&1
 
 	if $GATHER && [ ! -e "$expected_output" ]; then
@@ -43,7 +42,6 @@ lha_check_output() {
 	fi
 
 	rm -f "$wd/output.txt"
-	rmdir "$wd"
 }
 
 test_archive() {

--- a/test/test_common.sh
+++ b/test/test_common.sh
@@ -24,6 +24,10 @@
 
 set -eu
 
+# set up a temporary directory within which tests are to be run
+wd=$(mktemp -td lhasa-test.XXXXXX)
+trap "rmdir '$wd'" INT EXIT
+
 # Some of the test output is time zone-dependent, and output (eg.
 # from 'lha l') can be different in different time zones. Use the
 # TZ environment variable to force the behavior to the London


### PR DESCRIPTION
My previous patches added temp directory creation and deletion into each
individual test script. I'd missed deletion in two cases, meaning your
$TMPDIR would be left with unnecessary folders on each test run.

This patch fixes that problem but also moves temp directory creation
into test_common.sh. This results in temp directory sharing across
different invocations of the same tests, simplifying matters and shaving
a little bit off the test run execution time.
