### PR TITLE
Fix integer overflow in lha_decode_uint32(), lha_decode_be_uint32()

### DIFF
--- a/lib/lha_endian.c
+++ b/lib/lha_endian.c
@@ -27,8 +27,10 @@ uint16_t lha_decode_uint16(uint8_t *buf)
 
 uint32_t lha_decode_uint32(uint8_t *buf)
 {
-	return (uint32_t) (buf[0] | (buf[1] << 8)
-	                 | (buf[2] << 16) | (buf[3] << 24));
+	return ((uint32_t) buf[0])
+	     | ((uint32_t) buf[1] << 8)
+	     | ((uint32_t) buf[2] << 16)
+	     | ((uint32_t) buf[3] << 24);
 }
 
 uint64_t lha_decode_uint64(uint8_t *buf)
@@ -50,7 +52,9 @@ uint16_t lha_decode_be_uint16(uint8_t *buf)
 
 uint32_t lha_decode_be_uint32(uint8_t *buf)
 {
-	return (uint32_t) ((buf[0] << 24) | (buf[1] << 16)
-	                 | (buf[2] << 8) | buf[3]);
+	return ((uint32_t) buf[0] << 24)
+	     | ((uint32_t) buf[1] << 16)
+	     | ((uint32_t) buf[2] << 8)
+	     | ((uint32_t) buf[3]);
 }
 


### PR DESCRIPTION
`uint8_t` was automatically promoted to `int`, and then left shift by 24 could overflow it.
Add explicit casts to `uint32_t` to avoid undefined behavior.