### PR TITLE
Avoid SIGSEGV on decoding 8bit char filenames on NetBSD/amd64.

### DIFF
--- a/lib/lha_file_header.c
+++ b/lib/lha_file_header.c
@@ -194,7 +194,7 @@ static void fix_msdos_allcaps(LHAFileHeader *header)
 
 	if (header->path != NULL) {
 		for (i = 0; header->path[i] != '\0'; ++i) {
-			if (islower((unsigned) header->path[i])) {
+			if (islower((int)(unsigned char) header->path[i])) {
 				is_allcaps = 0;
 				break;
 			}
@@ -203,7 +203,7 @@ static void fix_msdos_allcaps(LHAFileHeader *header)
 
 	if (is_allcaps && header->filename != NULL) {
 		for (i = 0; header->filename[i] != '\0'; ++i) {
-			if (islower((unsigned) header->filename[i])) {
+			if (islower((int)(unsigned char) header->filename[i])) {
 				is_allcaps = 0;
 				break;
 			}
@@ -216,13 +216,13 @@ static void fix_msdos_allcaps(LHAFileHeader *header)
 		if (header->path != NULL) {
 			for (i = 0; header->path[i] != '\0'; ++i) {
 				header->path[i]
-				    = tolower((unsigned) header->path[i]);
+				    = tolower((int)(unsigned char) header->path[i]);
 			}
 		}
 		if (header->filename != NULL) {
 			for (i = 0; header->filename[i] != '\0'; ++i) {
 				header->filename[i]
-				    = tolower((unsigned) header->filename[i]);
+				    = tolower((int)(unsigned char) header->filename[i]);
 			}
 		}
 	}


### PR DESCRIPTION
Both 'path' and 'filename' members are defined as (char *) so 8bit character (ancient Japanese Shift_JIS etc.) in filenames is treated as a negative value and casting such a negative value to (unsigned) generates an unexpected large value.