### PR TITLE
Fix `make` on `srcdir != builddir`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,11 +10,11 @@ SOURCE_FILES=                             \
 	safe.c        safe.h
 
 lha_SOURCES=$(SOURCE_FILES)
-lha_CFLAGS=$(MAIN_CFLAGS) -I$(top_builddir)/lib/public -I$(top_builddir)
+lha_CFLAGS=$(MAIN_CFLAGS) -I$(top_builddir)/lib/public -I$(top_builddir) -I$(top_srcdir)/lib/public -I$(top_srcdir)
 lha_LDADD=$(top_builddir)/lib/liblhasa.la
 
 test_lha_SOURCES=$(SOURCE_FILES)
-test_lha_CFLAGS=$(TEST_CFLAGS) -I$(top_builddir)/lib/public -I$(top_builddir)
+test_lha_CFLAGS=$(TEST_CFLAGS) -I$(top_builddir)/lib/public -I$(top_builddir) -I$(top_srcdir)/lib/public -I$(top_srcdir)
 test_lha_LDADD=$(top_builddir)/lib/liblhasatest.a
 
 clean-local:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CFLAGS=$(TEST_CFLAGS) -I$(top_builddir)/lib/public -I$(top_builddir) -g
+AM_CFLAGS=$(TEST_CFLAGS) -I$(top_builddir)/lib/public -I$(top_builddir) -g -I$(top_srcdir)/lib/public -I$(top_srcdir)
 LDADD=$(top_builddir)/lib/liblhasatest.a libtestframework.a
 
 COMPILED_TESTS=                       \


### PR DESCRIPTION
```
$ cd /usr/src
$ git clone https://github.com/fragglet/lhasa.git
$ cd lhasa
$ autoreconf -fiv
$ cd /tmp/lhasa
$ /usr/src/lhasa/configure
$ make
/usr/src/lhasa/src/main.c:26:10: fatal error: lib/lha_arch.h: No such file or directory
   26 | #include "lib/lha_arch.h"
      |          ^~~~~~~~~~~~~~~~
```