### PR TITLE
Build on cygwin

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -38,6 +38,7 @@ liblhasatest_a_SOURCES=$(SRC) $(HEADER_FILES)
 
 liblhasa_la_CFLAGS=$(MAIN_CFLAGS)
 liblhasa_la_SOURCES=$(SRC) $(HEADER_FILES)
+liblhasa_la_LDFLAGS=-no-undefined
 
 clean-local:
 	rm -f *.gcno *.gcda *.c.gcov


### PR DESCRIPTION
```
libtool: warning: undefined symbols not allowed in x86_64-pc-cygwin shared libraries; building static only
```