### PR TITLE
Make more static arrays const

### DIFF
--- a/lib/ext_header.c
+++ b/lib/ext_header.c
@@ -106,7 +106,7 @@ static int ext_header_common_decoder(LHAFileHeader *header,
 	return 1;
 }
 
-static LHAExtHeaderType lha_ext_header_common = {
+static const LHAExtHeaderType lha_ext_header_common = {
 	LHA_EXT_HEADER_COMMON,
 	ext_header_common_decoder,
 	2
@@ -150,7 +150,7 @@ static int ext_header_filename_decoder(LHAFileHeader *header,
 	return 1;
 }
 
-static LHAExtHeaderType lha_ext_header_filename = {
+static const LHAExtHeaderType lha_ext_header_filename = {
 	LHA_EXT_HEADER_FILENAME,
 	ext_header_filename_decoder,
 	1
@@ -200,7 +200,7 @@ static int ext_header_path_decoder(LHAFileHeader *header,
 	return 1;
 }
 
-static LHAExtHeaderType lha_ext_header_path = {
+static const LHAExtHeaderType lha_ext_header_path = {
 	LHA_EXT_HEADER_PATH,
 	ext_header_path_decoder,
 	1
@@ -224,7 +224,7 @@ static int ext_header_windows_timestamps(LHAFileHeader *header,
 	return 1;
 }
 
-static LHAExtHeaderType lha_ext_header_windows_timestamps = {
+static const LHAExtHeaderType lha_ext_header_windows_timestamps = {
 	LHA_EXT_HEADER_WINDOWS_TIMESTAMPS,
 	ext_header_windows_timestamps,
 	24
@@ -243,7 +243,7 @@ static int ext_header_unix_perms_decoder(LHAFileHeader *header,
 	return 1;
 }
 
-static LHAExtHeaderType lha_ext_header_unix_perms = {
+static const LHAExtHeaderType lha_ext_header_unix_perms = {
 	LHA_EXT_HEADER_UNIX_PERMISSION,
 	ext_header_unix_perms_decoder,
 	2
@@ -262,7 +262,7 @@ static int ext_header_unix_uid_gid_decoder(LHAFileHeader *header,
 	return 1;
 }
 
-static LHAExtHeaderType lha_ext_header_unix_uid_gid = {
+static const LHAExtHeaderType lha_ext_header_unix_uid_gid = {
 	LHA_EXT_HEADER_UNIX_UID_GID,
 	ext_header_unix_uid_gid_decoder,
 	4
@@ -294,7 +294,7 @@ static int ext_header_unix_username_decoder(LHAFileHeader *header,
 	return 1;
 }
 
-static LHAExtHeaderType lha_ext_header_unix_username = {
+static const LHAExtHeaderType lha_ext_header_unix_username = {
 	LHA_EXT_HEADER_UNIX_USER,
 	ext_header_unix_username_decoder,
 	1
@@ -327,7 +327,7 @@ static int ext_header_unix_group_decoder(LHAFileHeader *header,
 	return 1;
 }
 
-static LHAExtHeaderType lha_ext_header_unix_group = {
+static const LHAExtHeaderType lha_ext_header_unix_group = {
 	LHA_EXT_HEADER_UNIX_GROUP,
 	ext_header_unix_group_decoder,
 	1
@@ -347,7 +347,7 @@ static int ext_header_unix_timestamp_decoder(LHAFileHeader *header,
 	return 1;
 }
 
-static LHAExtHeaderType lha_ext_header_unix_timestamp = {
+static const LHAExtHeaderType lha_ext_header_unix_timestamp = {
 	LHA_EXT_HEADER_UNIX_TIMESTAMP,
 	ext_header_unix_timestamp_decoder,
 	4
@@ -371,7 +371,7 @@ static int ext_header_os9_decoder(LHAFileHeader *header,
 	return 1;
 }
 
-static LHAExtHeaderType lha_ext_header_os9 = {
+static const LHAExtHeaderType lha_ext_header_os9 = {
 	LHA_EXT_HEADER_OS9,
 	ext_header_os9_decoder,
 	12
@@ -379,7 +379,7 @@ static LHAExtHeaderType lha_ext_header_os9 = {
 
 // Table of extended headers.
 
-static const LHAExtHeaderType *ext_header_types[] = {
+static const LHAExtHeaderType *const ext_header_types[] = {
 	&lha_ext_header_common,
 	&lha_ext_header_filename,
 	&lha_ext_header_path,

--- a/lib/lh1_decoder.c
+++ b/lib/lh1_decoder.c
@@ -712,7 +712,7 @@ static size_t lha_lh1_read(void *data, uint8_t *buf)
 	return result;
 }
 
-LHADecoderType lha_lh1_decoder = {
+const LHADecoderType lha_lh1_decoder = {
 	lha_lh1_init,
 	NULL,
 	lha_lh1_read,

--- a/lib/lh_new_decoder.c
+++ b/lib/lh_new_decoder.c
@@ -605,7 +605,7 @@ static size_t lha_lh_new_read(void *data, uint8_t *buf)
 	return result;
 }
 
-LHADecoderType DECODER_NAME = {
+const LHADecoderType DECODER_NAME = {
 	lha_lh_new_init,
 	NULL,
 	lha_lh_new_read,
@@ -617,7 +617,7 @@ LHADecoderType DECODER_NAME = {
 // This is a hack for -lh4-:
 
 #ifdef DECODER2_NAME
-LHADecoderType DECODER2_NAME = {
+const LHADecoderType DECODER2_NAME = {
 	lha_lh_new_init,
 	NULL,
 	lha_lh_new_read,

--- a/lib/lha_arch.h
+++ b/lib/lha_arch.h
@@ -51,7 +51,7 @@ typedef enum {
  *                    an error occurred in generating the string.
  */
 
-int lha_arch_vasprintf(char **result, char *fmt, va_list args);
+int lha_arch_vasprintf(char **result, const char *fmt, va_list args);
 
 /**
  * Change the mode of the specified FILE handle to be binary mode.

--- a/lib/lha_arch_unix.c
+++ b/lib/lha_arch_unix.c
@@ -40,7 +40,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 // implementation of it, but develop a compatible workaround for
 // operating systems that don't have it.
 
-int lha_arch_vasprintf(char **result, char *fmt, va_list args)
+int lha_arch_vasprintf(char **result, const char *fmt, va_list args)
 {
 	return vasprintf(result, fmt, args);
 }

--- a/lib/lha_arch_win32.c
+++ b/lib/lha_arch_win32.c
@@ -37,7 +37,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 static uint64_t unix_epoch_offset = 0;
 
-int lha_arch_vasprintf(char **result, char *fmt, va_list args)
+int lha_arch_vasprintf(char **result, const char *fmt, va_list args)
 {
 	int len;
 

--- a/lib/lha_basic_reader.c
+++ b/lib/lha_basic_reader.c
@@ -137,7 +137,7 @@ static size_t decoder_callback(void *buf, size_t buf_len, void *user_data)
 
 LHADecoder *lha_basic_reader_decode(LHABasicReader *reader)
 {
-	LHADecoderType *dtype;
+	const LHADecoderType *dtype;
 
 	if (reader->curr_file == NULL) {
 		return NULL;

--- a/lib/lha_decoder.c
+++ b/lib/lha_decoder.c
@@ -26,28 +26,28 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "lha_decoder.h"
 
 // Null decoder, used for -lz4-, -lh0-, -pm0-:
-extern LHADecoderType lha_null_decoder;
+extern const LHADecoderType lha_null_decoder;
 
 // LArc compression algorithms:
-extern LHADecoderType lha_lz5_decoder;
-extern LHADecoderType lha_lzs_decoder;
+extern const LHADecoderType lha_lz5_decoder;
+extern const LHADecoderType lha_lzs_decoder;
 
 // LHarc compression algorithms:
-extern LHADecoderType lha_lh1_decoder;
-extern LHADecoderType lha_lh4_decoder;
-extern LHADecoderType lha_lh5_decoder;
-extern LHADecoderType lha_lh6_decoder;
-extern LHADecoderType lha_lh7_decoder;
-extern LHADecoderType lha_lhx_decoder;
-extern LHADecoderType lha_lk7_decoder;
+extern const LHADecoderType lha_lh1_decoder;
+extern const LHADecoderType lha_lh4_decoder;
+extern const LHADecoderType lha_lh5_decoder;
+extern const LHADecoderType lha_lh6_decoder;
+extern const LHADecoderType lha_lh7_decoder;
+extern const LHADecoderType lha_lhx_decoder;
+extern const LHADecoderType lha_lk7_decoder;
 
 // PMarc compression algorithms:
-extern LHADecoderType lha_pm1_decoder;
-extern LHADecoderType lha_pm2_decoder;
+extern const LHADecoderType lha_pm1_decoder;
+extern const LHADecoderType lha_pm2_decoder;
 
-static struct {
-	char *name;
-	LHADecoderType *dtype;
+static const struct {
+	const char *name;
+	const LHADecoderType *dtype;
 } decoders[] = {
 	{ "-lz4-", &lha_null_decoder },
 	{ "-lz5-", &lha_lz5_decoder },
@@ -65,7 +65,7 @@ static struct {
 	{ "-pm2-", &lha_pm2_decoder },
 };
 
-LHADecoder *lha_decoder_new(LHADecoderType *dtype,
+LHADecoder *lha_decoder_new(const LHADecoderType *dtype,
                             LHADecoderCallback callback,
                             void *callback_data,
                             size_t stream_length)
@@ -108,7 +108,7 @@ LHADecoder *lha_decoder_new(LHADecoderType *dtype,
 	return decoder;
 }
 
-LHADecoderType *lha_decoder_for_name(char *name)
+const LHADecoderType *lha_decoder_for_name(const char *name)
 {
 	unsigned int i;
 

--- a/lib/lha_decoder.h
+++ b/lib/lha_decoder.h
@@ -81,7 +81,7 @@ struct _LHADecoder {
 
 	/** Type of decoder (algorithm) */
 
-	LHADecoderType *dtype;
+	const LHADecoderType *dtype;
 
 	/** Callback function to monitor decoder progress. */
 

--- a/lib/lha_file_header.c
+++ b/lib/lha_file_header.c
@@ -56,8 +56,8 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 char *lha_file_header_full_path(LHAFileHeader *header)
 {
-	char *path;
-	char *filename;
+	const char *path;
+	const char *filename;
 	char *result;
 
 	if (header->path != NULL) {

--- a/lib/lz5_decoder.c
+++ b/lib/lz5_decoder.c
@@ -187,7 +187,7 @@ static size_t lha_lz5_read(void *data, uint8_t *buf)
 	return result;
 }
 
-LHADecoderType lha_lz5_decoder = {
+const LHADecoderType lha_lz5_decoder = {
 	lha_lz5_init,
 	NULL,
 	lha_lz5_read,

--- a/lib/lzs_decoder.c
+++ b/lib/lzs_decoder.c
@@ -145,7 +145,7 @@ static size_t lha_lzs_read(void *data, uint8_t *buf)
 	return result;
 }
 
-LHADecoderType lha_lzs_decoder = {
+const LHADecoderType lha_lzs_decoder = {
 	lha_lzs_init,
 	NULL,
 	lha_lzs_read,

--- a/lib/macbinary.c
+++ b/lib/macbinary.c
@@ -425,7 +425,7 @@ static size_t macbinary_decoder_read(void *_decoder, uint8_t *buf)
 	return result;
 }
 
-static LHADecoderType macbinary_decoder_type = {
+static const LHADecoderType macbinary_decoder_type = {
 	macbinary_decoder_init,
 	NULL,
 	macbinary_decoder_read,

--- a/lib/null_decoder.c
+++ b/lib/null_decoder.c
@@ -50,7 +50,7 @@ static size_t lha_null_read(void *data, uint8_t *buf)
 	return decoder->callback(buf, BLOCK_READ_SIZE, decoder->callback_data);
 }
 
-LHADecoderType lha_null_decoder = {
+const LHADecoderType lha_null_decoder = {
 	lha_null_init,
 	NULL,
 	lha_null_read,

--- a/lib/pm1_decoder.c
+++ b/lib/pm1_decoder.c
@@ -703,7 +703,7 @@ static size_t lha_pm1_read(void *data, uint8_t *buf)
 	}
 }
 
-LHADecoderType lha_pm1_decoder = {
+const LHADecoderType lha_pm1_decoder = {
 	lha_pm1_init,
 	NULL,
 	lha_pm1_read,

--- a/lib/pm2_decoder.c
+++ b/lib/pm2_decoder.c
@@ -538,7 +538,7 @@ static size_t lha_pm2_decoder_read(void *data, uint8_t *buf)
 	return result;
 }
 
-LHADecoderType lha_pm2_decoder = {
+const LHADecoderType lha_pm2_decoder = {
 	lha_pm2_decoder_init,
 	NULL,
 	lha_pm2_decoder_read,

--- a/lib/public/lha_decoder.h
+++ b/lib/public/lha_decoder.h
@@ -100,7 +100,7 @@ typedef void (*LHADecoderProgressCallback)(unsigned int num_blocks,
  *                       is no decoder type for the specified name.
  */
 
-LHADecoderType *lha_decoder_for_name(char *name);
+const LHADecoderType *lha_decoder_for_name(const char *name);
 
 /**
  * Allocate a new decoder for the specified type.
@@ -114,7 +114,7 @@ LHADecoderType *lha_decoder_for_name(char *name);
  * @return               Pointer to the new decoder, or NULL for failure.
  */
 
-LHADecoder *lha_decoder_new(LHADecoderType *dtype,
+LHADecoder *lha_decoder_new(const LHADecoderType *dtype,
                             LHADecoderCallback callback,
                             void *callback_data,
                             size_t stream_length);

--- a/src/extract.c
+++ b/src/extract.c
@@ -36,8 +36,8 @@ typedef struct {
 	int invoked;
 	LHAFileHeader *header;
 	LHAOptions *options;
-	char *filename;
-	char *operation;
+	const char *filename;
+	const char *operation;
 } ProgressCallbackData;
 
 // Given a file header structure, get the path to extract to.
@@ -109,14 +109,14 @@ static char *file_full_path(LHAFileHeader *header, LHAOptions *options)
 	return result;
 }
 
-static void print_filename(char *filename, char *status)
+static void print_filename(const char *filename, const char *status)
 {
 	printf("\r");
 	safe_printf("%s", filename);
 	printf("\t- %s  ", status);
 }
 
-static void print_filename_brief(char *filename)
+static void print_filename_brief(const char *filename)
 {
 	printf("\r");
 	safe_printf("%s :", filename);
@@ -337,7 +337,7 @@ static int make_parent_directories(char *orig_path)
 // Prompt the user with a message, and return the first character of
 // the typed response.
 
-static char prompt_user(char *message)
+static char prompt_user(const char *message)
 {
 	char result;
 	int c;

--- a/src/list.c
+++ b/src/list.c
@@ -38,7 +38,7 @@ typedef struct {
 } FileStatistics;
 
 typedef struct {
-	char *name;
+	const char *name;
 	unsigned int width;
 	void (*handler)(LHAFileHeader *header);
 	void (*footer)(FileStatistics *stats);
@@ -46,7 +46,7 @@ typedef struct {
 
 // Display OS type:
 
-static char *os_type_to_string(uint8_t os_type)
+static const char *os_type_to_string(uint8_t os_type)
 {
 	switch (os_type) {
 		case LHA_OS_TYPE_MSDOS:
@@ -161,7 +161,7 @@ static void permission_column_footer(FileStatistics *stats)
 	printf(" Total    ");
 }
 
-static ListColumn permission_column = {
+static const ListColumn permission_column = {
 	" PERMSSN", 10,
 	permission_column_print,
 	permission_column_footer
@@ -190,7 +190,7 @@ static void unix_uid_gid_column_footer(FileStatistics *stats)
 	}
 }
 
-static ListColumn unix_uid_gid_column = {
+static const ListColumn unix_uid_gid_column = {
 	" UID  GID", 11,
 	unix_uid_gid_column_print,
 	unix_uid_gid_column_footer
@@ -208,7 +208,7 @@ static void packed_column_footer(FileStatistics *stats)
 	printf("%7lu", (unsigned long) stats->compressed_length);
 }
 
-static ListColumn packed_column = {
+static const ListColumn packed_column = {
 	" PACKED", 7,
 	packed_column_print,
 	packed_column_footer
@@ -226,7 +226,7 @@ static void size_column_footer(FileStatistics *stats)
 	printf("%7lu", (unsigned long) stats->length);
 }
 
-static ListColumn size_column = {
+static const ListColumn size_column = {
 	"   SIZE", 7,
 	size_column_print,
 	size_column_footer
@@ -263,7 +263,7 @@ static void ratio_column_footer(FileStatistics *stats)
 	}
 }
 
-static ListColumn ratio_column = {
+static const ListColumn ratio_column = {
 	" RATIO", 6,
 	ratio_column_print,
 	ratio_column_footer
@@ -276,7 +276,7 @@ static void method_crc_column_print(LHAFileHeader *header)
 	printf("%-5s %04x", header->compress_method, header->crc);
 }
 
-static ListColumn method_crc_column = {
+static const ListColumn method_crc_column = {
 	"METHOD CRC", 10,
 	method_crc_column_print
 };
@@ -380,13 +380,13 @@ static void full_timestamp_column_footer(FileStatistics *stats)
 	output_full_timestamp(stats->timestamp);
 };
 
-static ListColumn timestamp_column = {
+static const ListColumn timestamp_column = {
 	"    STAMP", 12,
 	timestamp_column_print,
 	timestamp_column_footer
 };
 
-static ListColumn full_timestamp_column = {
+static const ListColumn full_timestamp_column = {
 	"    STAMP", 19,
 	full_timestamp_column_print,
 	full_timestamp_column_footer
@@ -407,12 +407,12 @@ static void name_column_print(LHAFileHeader *header)
 	}
 }
 
-static ListColumn name_column = {
+static const ListColumn name_column = {
 	"       NAME", 20,
 	name_column_print
 };
 
-static ListColumn short_name_column = {
+static const ListColumn short_name_column = {
 	"      NAME", 13,
 	name_column_print
 };
@@ -441,7 +441,7 @@ static void whole_line_name_column_print(LHAFileHeader *header)
 	printf("\n");
 }
 
-static ListColumn whole_line_name_column = {
+static const ListColumn whole_line_name_column = {
 	"", 0,
 	whole_line_name_column_print
 };
@@ -453,7 +453,7 @@ static void header_level_column_print(LHAFileHeader *header)
 	printf("[%i]", header->header_level);
 }
 
-static ListColumn header_level_column = {
+static const ListColumn header_level_column = {
 	" LV", 3,
 	header_level_column_print
 };
@@ -462,9 +462,9 @@ static ListColumn header_level_column = {
 // column with a width > 0. Beyond this last column it isn't necessary
 // to print any more whitespace.
 
-static ListColumn *last_column(ListColumn **columns)
+static const ListColumn *last_column(const ListColumn *const *columns)
 {
-	ListColumn *last;
+	const ListColumn *last;
 	unsigned int i;
 
 	last = NULL;
@@ -480,9 +480,9 @@ static ListColumn *last_column(ListColumn **columns)
 
 // Print the names of the column headings at the top of the file list.
 
-static void print_list_headings(ListColumn **columns)
+static void print_list_headings(const ListColumn *const *columns)
 {
-	ListColumn *last;
+	const ListColumn *last;
 	unsigned int i, j;
 
 	last = last_column(columns);
@@ -502,9 +502,9 @@ static void print_list_headings(ListColumn **columns)
 
 // Print separator lines shown at top and bottom of file list.
 
-static void print_list_separators(ListColumn **columns)
+static void print_list_separators(const ListColumn *const *columns)
 {
-	ListColumn *last;
+	const ListColumn *last;
 	unsigned int i, j;
 
 	last = last_column(columns);
@@ -524,9 +524,9 @@ static void print_list_separators(ListColumn **columns)
 
 // Print a row in the list corresponding to a file.
 
-static void print_columns(ListColumn **columns, LHAFileHeader *header)
+static void print_columns(const ListColumn *const *columns, LHAFileHeader *header)
 {
-	ListColumn *last;
+	const ListColumn *last;
 	unsigned int i;
 
 	last = last_column(columns);
@@ -544,7 +544,7 @@ static void print_columns(ListColumn **columns, LHAFileHeader *header)
 
 // Print footer information shown at end of list (overall file stats)
 
-static void print_footers(ListColumn **columns, FileStatistics *stats)
+static void print_footers(const ListColumn *const *columns, FileStatistics *stats)
 {
 	unsigned int i, j, len;
 	unsigned int num_columns;
@@ -599,7 +599,7 @@ static unsigned int read_file_timestamp(FILE *fstream)
 // Different columns are provided for basic and verbose modes.
 
 static void list_file_contents(LHAFilter *filter, FILE *fstream,
-                               LHAOptions *options, ListColumn **columns)
+                               LHAOptions *options, const ListColumn *const *columns)
 {
 	FileStatistics stats;
 
@@ -637,7 +637,7 @@ static void list_file_contents(LHAFilter *filter, FILE *fstream,
 
 // Used for lha -l:
 
-static ListColumn *normal_column_headers[] = {
+static const ListColumn *const normal_column_headers[] = {
 	&permission_column,
 	&unix_uid_gid_column,
 	&size_column,
@@ -649,7 +649,7 @@ static ListColumn *normal_column_headers[] = {
 
 // Used for lha -lv:
 
-static ListColumn *normal_column_headers_verbose[] = {
+static const ListColumn *const normal_column_headers_verbose[] = {
 	&whole_line_name_column,
 	&permission_column,
 	&unix_uid_gid_column,
@@ -664,7 +664,7 @@ static ListColumn *normal_column_headers_verbose[] = {
 
 void list_file_basic(LHAFilter *filter, LHAOptions *options, FILE *fstream)
 {
-	ListColumn **headers;
+	const ListColumn *const *headers;
 
 	if (options->verbose) {
 		headers = normal_column_headers_verbose;
@@ -677,7 +677,7 @@ void list_file_basic(LHAFilter *filter, LHAOptions *options, FILE *fstream)
 
 // Used for lha -v:
 
-static ListColumn *verbose_column_headers[] = {
+static const ListColumn *const verbose_column_headers[] = {
 	&permission_column,
 	&unix_uid_gid_column,
 	&packed_column,
@@ -691,7 +691,7 @@ static ListColumn *verbose_column_headers[] = {
 
 // Used for lha -vv:
 
-static ListColumn *verbose_column_headers_verbose[] = {
+static const ListColumn *const verbose_column_headers_verbose[] = {
 	&whole_line_name_column,
 	&permission_column,
 	&unix_uid_gid_column,
@@ -708,7 +708,7 @@ static ListColumn *verbose_column_headers_verbose[] = {
 
 void list_file_verbose(LHAFilter *filter, LHAOptions *options, FILE *fstream)
 {
-	ListColumn **headers;
+	const ListColumn *const *headers;
 
 	if (options->verbose) {
 		headers = verbose_column_headers_verbose;

--- a/src/safe.c
+++ b/src/safe.c
@@ -65,7 +65,7 @@ static void safe_output(FILE *stream, unsigned char *str)
 // Note: all escape characters are considered potentially malicious,
 // including newline characters.
 
-int safe_fprintf(FILE *stream, char *format, ...)
+int safe_fprintf(FILE *stream, const char *format, ...)
 {
 	va_list args;
 	int result;
@@ -85,7 +85,7 @@ int safe_fprintf(FILE *stream, char *format, ...)
 	return result;
 }
 
-int safe_printf(char *format, ...)
+int safe_printf(const char *format, ...)
 {
 	va_list args;
 	int result;

--- a/src/safe.h
+++ b/src/safe.h
@@ -21,7 +21,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef LHASA_SAFE_H
 #define LHASA_SAFE_H
 
-int safe_fprintf(FILE *stream, char *format, ...);
-int safe_printf(char *format, ...);
+int safe_fprintf(FILE *stream, const char *format, ...);
+int safe_printf(const char *format, ...);
 
 #endif /* #ifndef LHASA_SAFE_H */


### PR DESCRIPTION
This is split out from libxmp/libxmp#752 - however it affects the public declarations for `lha_decoder_for_name` and `lha_decoder_new`.