### PR TITLE
Fix for the broken github link in the official website. Close #54.

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
        replacement.
     </p>
     <p>
-       Please report any bugs <a href=https://github.com/fragglet/lhasa">
+       Please report any bugs <a href="https://github.com/fragglet/lhasa">
        on GitHub</a>, where you can also find the latest changes to the
        codebase.
     </p>


### PR DESCRIPTION
https://github.com/fragglet/lhasa/issues/54